### PR TITLE
scale canvas for higher resolutions

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,8 @@ Then add it to your component files
 
 ### Scale
 
-Improves the resolution of the canvas. For more detailed drawings. Example: Set the canvas width and height props to 2x the desired dimensions, set :scale=2 and finally set the dimensions of the parent element of the canvas to the originally desired dimensions.
+Improves the resolution of the canvas. For more detailed drawings.
+How to use: Set the canvas width and height props to 2x the desired dimensions (1000x1000 px), set :scale=2 and finally set the dimensions of the parent element of the canvas to the originally desired dimensions (500x500 px).
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ Support for both Vue 3 and Vue 2 + [Composition API](https://github.com/vuejs/co
 <br><br>
 
 # Installation
+
 Install using package manager:
+
 ```bash
 npm install --save-dev vue-drawing-canvas
 
@@ -48,24 +50,23 @@ npm install --save-dev vue-drawing-canvas @vue/composition-api
 ```
 
 Then add it to your component files
+
 ```html
 <!-- MyComponent.vue -->
 
 <template>
-  <vue-drawing-canvas
-    ref="VueCanvasDrawing"
-  />
+  <vue-drawing-canvas ref="VueCanvasDrawing" />
 </template>
 
 <script>
-import VueDrawingCanvas from 'vue-drawing-canvas';
+  import VueDrawingCanvas from "vue-drawing-canvas";
 
-export default {
-  name: 'MyComponent',
-  components: {
-    VueDrawingCanvas
-  }
-}
+  export default {
+    name: "MyComponent",
+    components: {
+      VueDrawingCanvas,
+    },
+  };
 </script>
 ```
 
@@ -77,26 +78,27 @@ export default {
 
 <br>
 
-| Name            |          Type         |    Default Value   | Description                                                                                                                      |
-| --------------- | :-------------------: | :----------------: | -------------------------------------------------------------------------------------------------------------------------------- |
-| canvasId        | String                | `VueDrawingCanvas` | Specifies your canvas id                                                                                                         |
-| width           | String, Number        | `600`              | Specifies canvas width                                                                                                           |
-| height          | String, Number        | `400`              | Specifies canvas height                                                                                                          |
-| image           | String                |                    | Your v-model to get canvas output to an base64 image                                                                             |
-| strokeType      | String                | `"dash"`           | Specifies stroke type to draw on canvas.<br><br>Accepted value `"dash"`, `"circle"`, `"square"`, `"triangle"`, `"half_triangle"` |
-| fillShape       | Boolean               | `false`            | Specifies if the shape must be filled with the current fill style                                                                |
-| eraser          | Boolean               | `false`            | Props to change state from drawing to erasing                                                                                    |
-| color           | String                | `"#000000"`        | Specifies the color, gradient, or pattern to use for the strokes                                                                 |
-| lineWidth       | Number                | `5`                | Sets the thickness of line                                                                                                       |
-| lock            | Boolean               | `false`            | Lock canvas for drawing                                                                                                          |
-| backgroundColor | String                | `"#FFFFFF"`        | Set background color on your canvas                                                                                              |
-| backgroundImage | String                |                    | Set background image on your canvas<br><br>***Be carefull for performance issue when using this props !!***                      |
-| initialImage    | Array                 | `[]`               | Draw strokes and shapes from canvas you've worked before. [Demo](https://codesandbox.io/s/vue-drawing-canvas-107-rc1-dcoiy)      |
-| additionalImages | Array                | `[]`               | Accept Array of [watermark](#watermark-object) Object to draw either text or insert multiple image on canvas<br><br>***Be carefull for performance issue when using this props !!*** |
-| classes         | Array, String, Object |                    | Specifies your own classes to canvas                                                                                             |
-| styles          | Array, String, Object |                    | Specifies your own styles to canvas                                                                                              |
-| watermark       | Object                |                    | Put watermark text/image on your image output<br><br>(see details in the next section below)                                     |
-| saveAs          | String                | `"png"`            | Specifies output type. This props accept either `"png"` or `"jpeg"`                                                              |
+| Name             |         Type          |   Default Value    | Description                                                                                                                                                                          |
+| ---------------- | :-------------------: | :----------------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| canvasId         |        String         | `VueDrawingCanvas` | Specifies your canvas id                                                                                                                                                             |
+| width            |    String, Number     |       `600`        | Specifies canvas width                                                                                                                                                               |
+| height           |    String, Number     |       `400`        | Specifies canvas height                                                                                                                                                              |
+| image            |        String         |                    | Your v-model to get canvas output to an base64 image                                                                                                                                 |
+| strokeType       |        String         |      `"dash"`      | Specifies stroke type to draw on canvas.<br><br>Accepted value `"dash"`, `"circle"`, `"square"`, `"triangle"`, `"half_triangle"`                                                     |
+| fillShape        |        Boolean        |      `false`       | Specifies if the shape must be filled with the current fill style                                                                                                                    |
+| eraser           |        Boolean        |      `false`       | Props to change state from drawing to erasing                                                                                                                                        |
+| color            |        String         |    `"#000000"`     | Specifies the color, gradient, or pattern to use for the strokes                                                                                                                     |
+| lineWidth        |        Number         |        `5`         | Sets the thickness of line                                                                                                                                                           |
+| lock             |        Boolean        |      `false`       | Lock canvas for drawing                                                                                                                                                              |
+| backgroundColor  |        String         |    `"#FFFFFF"`     | Set background color on your canvas                                                                                                                                                  |
+| backgroundImage  |        String         |                    | Set background image on your canvas<br><br>**_Be carefull for performance issue when using this props !!_**                                                                          |
+| initialImage     |         Array         |        `[]`        | Draw strokes and shapes from canvas you've worked before. [Demo](https://codesandbox.io/s/vue-drawing-canvas-107-rc1-dcoiy)                                                          |
+| additionalImages |         Array         |        `[]`        | Accept Array of [watermark](#watermark-object) Object to draw either text or insert multiple image on canvas<br><br>**_Be carefull for performance issue when using this props !!_** |
+| classes          | Array, String, Object |                    | Specifies your own classes to canvas                                                                                                                                                 |
+| styles           | Array, String, Object |                    | Specifies your own styles to canvas                                                                                                                                                  |
+| watermark        |        Object         |                    | Put watermark text/image on your image output<br><br>(see details in the next section below)                                                                                         |
+| saveAs           |        String         |      `"png"`       | Specifies output type. This props accept either `"png"` or `"jpeg"`                                                                                                                  |
+| scale            |        Number         |         1          | transforms the canvas via the setTransform(...) method. Parent Element has to handle the real dimensions                                                                             |
 
 <br>
 
@@ -107,7 +109,7 @@ export default {
 ```js
 {
   // Specifies your watermark type. Type can be either "Text" or "Image"
-  // 
+  //
   // type: String
   // required: true
   // validator: (value) => { return ["Text", "Image"].includes(value) }
@@ -115,72 +117,72 @@ export default {
   // Specifies your watermark source
   // If type is "Text" enter your watermark text here
   // if type if "Image" enter your uploaded file createObjectURL(event.target.files[0]) Work best with .png file
-  // 
+  //
   // type: String
   // required: true
   source: "Watermark",
   // The x-axis coordinate of the point at which to begin drawing the watermark,
   // in pixels
-  // 
+  //
   // type: Number
   // required: true
   x: 200,
   // The y-axis coordinate of the point at which to begin drawing the watermark,
   // in pixels
-  // 
+  //
   // type: Number
   // required: true
   y: 180,
   // Specifies width and height for your watermark image
-  // 
+  //
   // type: Object
   // required: false
   imageStyle: {
     // The width to draw the image in the canvas
-    // 
+    //
     // type: Number
     // required: false
     // default: () => this.width
     width: 600,
     // The height to draw the image in the canvas
-    // 
+    //
     // type: Number
     // required: false
     // default: () => this.height
     height: 400
   },
   // Specifies text style for your watermark
-  // 
+  //
   // type: Object
   // required: false
   fontStyle: {
     // The maximum number of pixels wide the text may be once rendered.
-    // If not specified, there is no limit to the width of the text. 
-    // 
+    // If not specified, there is no limit to the width of the text.
+    //
     // type: Number
     // required: false
     width: 200,
     // Sets the height of text in pixels. Usually this value has same value with font
-    // 
+    //
     // type: Number
     // required: false
     // default: () => 20
     lineHeight: 48,
     // Specifies the color, gradient, or pattern to use for the text
-    // 
+    //
     // type: String
     // required: false
     // default: () => '#000000'
     color: '#FF0000',
     // Specifies the current text style to use when drawing text.
     // font: '{fontWeight} {fontSize} {fontFamily}'
-    // 
+    //
     // type: String
     // required: false
     // default: () => '20px serif'
     font: 'bold 48px serif',
     // Specifies drawing type to use when drawing text.
-    // 
+    //
     // type: String
     // required: false
     // validator: (value) => { return ["fill", "stroke"].includes(value) }
@@ -188,21 +190,21 @@ export default {
     drawType: 'fill',
     // Specifies the current text alignment used when drawing text
     // The alignment is relative to the x value
-    // 
+    //
     // type: String
     // required: false
     // validator: (value) => { return ["left", "right", "center", "start", "end"].includes(value) }
     // default: () => 'start'
     textAlign: 'left',
     // Specifies the current text baseline used when drawing text
-    // 
+    //
     // type: String
     // required: false
     // validator: (value) => { return ["top", "hanging", "middle", "alphabetic", "ideographic", "bottom"].includes(value) }
     // default: () => 'alphabetic'
     textBaseline: 'top',
     // The rotation angle, clockwise in radians
-    // 
+    //
     // type: Number
     // required: false
     rotate: 45
@@ -212,26 +214,34 @@ export default {
 
 <br><br>
 
+### Scale
+
+Improves the resolution of the canvas. For more detailed drawings. Example: Set the canvas width and height props to 2x the desired dimensions, set :scale=2 and finally set the dimensions of the parent element of the canvas to the originally desired dimensions.
+
+<br>
+
 ## Methods
 
 <br>
 
-| Method Name           | Return Value                    | Description                                           |
-|-----------------------|:-------------------------------:|-------------------------------------------------------|
-| getCoordinates(event) | `{ x: 0, y: 0 }`                | Get x-axis and y-axis coordinates from current canvas |
+| Method Name           |          Return Value           | Description                                           |
+| --------------------- | :-----------------------------: | ----------------------------------------------------- |
+| getCoordinates(event) |        `{ x: 0, y: 0 }`         | Get x-axis and y-axis coordinates from current canvas |
 | reset()               |                                 | Reset current canvas to new state                     |
 | undo()                |                                 | Remove last drawing stroke on current canvas          |
 | redo()                |                                 | Re-draw last removed stroke on current canvas         |
 | redraw()              |                                 | Redraw all strokes on current canvas                  |
-| isEmpty()             | `true` or `false`               | Get current canvas empty state                        |
+| isEmpty()             |        `true` or `false`        | Get current canvas empty state                        |
 | getAllStrokes()       | _`Array of strokes and shapes`_ | Get all strokes and shapes from canvas                |
 
 <br><br>
 
 # Changelog
+
 [Read here](https://github.com/razztyfication/vue-drawing-canvas/blob/master/CHANGELOG.md)
 
 <br><br>
 
 # License
+
 [MIT](https://github.com/razztyfication/vue-drawing-canvas/blob/master/LICENSE.md)

--- a/dist/vue-drawing-canvas.esm.js
+++ b/dist/vue-drawing-canvas.esm.js
@@ -79,6 +79,10 @@ var VueDrawingCanvas = /*#__PURE__*/defineComponent({
     additionalImages: {
       type: Array,
       default: () => []
+    },
+    scale:{
+      type: Number,
+      default: () => 1
     }
   },
 
@@ -107,6 +111,7 @@ var VueDrawingCanvas = /*#__PURE__*/defineComponent({
   mounted() {
     this.setContext();
     this.$nextTick(() => {
+      this.setScale();
       this.drawInitialImage();
       this.drawAdditionalImages();
     });
@@ -122,6 +127,12 @@ var VueDrawingCanvas = /*#__PURE__*/defineComponent({
       let canvas = document.querySelector('#' + this.canvasId);
       this.context = this.context ? this.context : canvas.getContext('2d');
       await this.setBackground();
+    },
+
+    setScale(){
+      if(this.scale==1) return;
+      let ctx = document.querySelector('#' + this.canvasId).getContext("2d");
+      ctx.setTransform(this.scale, 0, 0, this.scale, 0, 0);
     },
 
     drawInitialImage() {

--- a/src/VueDrawingCanvas.ts
+++ b/src/VueDrawingCanvas.ts
@@ -115,6 +115,10 @@ export default /*#__PURE__*/defineComponent({
     additionalImages: {
       type: Array,
       default: (): any => []
+    },
+    scale:{
+      type: Number,
+      default: () => 1
     }
   },
   data(): DataInit {
@@ -138,6 +142,7 @@ export default /*#__PURE__*/defineComponent({
   mounted() {
     this.setContext();
     this.$nextTick(() => {
+      this.setScale()
       this.drawInitialImage()
       this.drawAdditionalImages()
     })
@@ -148,6 +153,15 @@ export default /*#__PURE__*/defineComponent({
     }
   },
   methods: {
+
+    setScale(){
+      if(this.scale==1) return
+      let canvas: HTMLCanvasElement = <HTMLCanvasElement>document.querySelector('#'+this.canvasId);
+      let ctx = canvas.getContext("2d");
+      if(!ctx) return
+      ctx.setTransform(this.scale, 0, 0, this.scale, 0, 0);
+    },
+
     async setContext() {
       let canvas: HTMLCanvasElement = <HTMLCanvasElement>document.querySelector('#'+this.canvasId);
       this.context = this.context ? this.context : canvas.getContext('2d');


### PR DESCRIPTION
Added a new prop called 'scale'. This can be used to scale the canvas for sharper drawing.
Example: Set the canvas size to width:1000px and height:500px, scale it down with css to 500x250px. Set scale to 2.
Image will be a lot sharper