### PR TITLE
Fix default freehand drawing and ERR_OSSL_EVP_UNSUPPORTED

### DIFF
--- a/dev/serve.vue
+++ b/dev/serve.vue
@@ -33,7 +33,7 @@ export default defineComponent({
       color: '#000000',
       strokeType: 'dash',
       lineCap: 'square',
-      lineJoin: 'miter',
+      lineJoin: 'round',
       backgroundColor: '#FFFFFF',
       backgroundImage: null,
       watermark: null,

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "serve": "vue-cli-service serve dev/serve.ts",
+    "serve": "cross-env NODE_OPTIONS=--openssl-legacy-provider vue-cli-service serve dev/serve.ts",
     "prebuild": "rimraf ./dist",
     "build": "cross-env NODE_ENV=production rollup --config build/rollup.config.js --format es",
     "postbuild": "rimraf ./dist/types/dev ./dist/types/src/entry.d.ts"

--- a/src/VueDrawingCanvas.ts
+++ b/src/VueDrawingCanvas.ts
@@ -85,9 +85,9 @@ export default /*#__PURE__*/defineComponent({
     lineJoin: {
       type: String,
       validator: (value: string): boolean => {
-        return ['miter', 'round', 'bevel'].indexOf(value) !== -1
+        return ['round', 'miter',  'bevel'].indexOf(value) !== -1
       },
-      default: () => 'miter'
+      default: () => 'round'
     },
     lock: {
       type: Boolean,


### PR DESCRIPTION
There was spikes when miter
![image](https://github.com/user-attachments/assets/c954c828-35c4-4145-a5e0-8edd1748179a)
with round dash lines :
![image](https://github.com/user-attachments/assets/163accd1-e3f3-499c-b0ed-34d5788285c9)
